### PR TITLE
feature/TAMAPI-2440 spark 2.2.0 -> 2.2.3

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -24,7 +24,7 @@ RUN sbt update
 # add the rest of the code
 COPY . .
 
-ENV SPARK_HOME /tmp/spark-2.2.0-bin-hadoop2.7
+ENV SPARK_HOME /tmp/spark-2.2.3-bin-hadoop2.7
 ENV JAVA_OPTIONS "-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
 
 CMD ["/usr/src/app/run_tests.sh"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -24,7 +24,7 @@ RUN sbt update
 # add the rest of the code
 COPY . .
 
-ENV SPARK_HOME /tmp/spark-2.2.3-bin-hadoop2.7
+ENV SPARK_HOME /tmp/spark-2.2.0-bin-hadoop2.7
 ENV JAVA_OPTIONS "-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
 
 CMD ["/usr/src/app/run_tests.sh"]

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val dockerSettings = Seq(
       run("mkdir", "-p", "/database")
       runRaw(
         s"""
-           |wget http://d3kbcqa49mib13.cloudfront.net/$sparkBuild.tgz && \\
+           |wget https://archive.apache.org/dist/spark/spark-2.2.3/$sparkBuild.tgz && \\
            |tar -xvf $sparkBuild.tgz && \\
            |cd $sparkBuild && \\
            |$sparkBuildCmd && \\

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,7 +1,7 @@
 import scala.util.Properties.isJavaAtLeast
 
 object Versions {
-  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.2.0")
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.2.3")
 
   lazy val akka = "2.4.9"
   lazy val cassandra = "3.3.0"


### PR DESCRIPTION
Nie poprawiałem zależności do Continuous Integration i Pythona, bo nawet nie miałbym jak tego sprawdzić.

Obraz zdeployowany ręcznie:
`turbineanalytics/spark-jobserver:0.8.0-spark-2.2.3`