### PR TITLE
feature / TAMAPI-2582 Changed garbage collector to G1 and added gc diagnostic options

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -88,10 +88,7 @@ export SPARK_HOME
 export YARN_CONF_DIR
 export HADOOP_CONF_DIR
 
-GC_OPTS_BASE="-XX:+UseConcMarkSweepGC
-         -verbose:gc -XX:+PrintGCTimeStamps
-         -XX:MaxPermSize=512m
-         -XX:+CMSClassUnloadingEnabled "
+GC_OPTS_BASE="-XX:+UseG1GC -XX:+PrintFlagsFinal -XX:+PrintReferenceGC -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintAdaptiveSizePolicy -XX:+UnlockDiagnosticVMOptions -XX:+G1SummarizeConcMark "
 
 JAVA_OPTS_BASE="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY
          -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"


### PR DESCRIPTION
Wypchnąłem obraz `turbineanalytics/spark-jobserver:0.9.1-spark-2.2.3-G1`.

Zbudowany poprzez `sbt docker` na branchu ficzerowym.

Czy taka numeracja milestone'a jest OK, bo mi średnio pasuje? Dałem 0.9.1 od tego co jest w upstreamowym repo, ale mogą być problemy z późniejszymi rilisami.